### PR TITLE
get Python from homebrew on macos-11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,18 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup python
+        if: matrix.os != 'macos-11.0'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+
+      - name: setup homebrew python
+        if: matrix.os == 'macos-11.0'
+        run: |
+          brew install python@${{ matrix.python }}
+          env_dir=$(mktemp -d)
+          /usr/local/opt/python@${{ matrix.python }}/bin/python3 -mvenv "$env_dir"
+          echo "PATH=$env_dir/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: install dependencies
         run: |


### PR DESCRIPTION
should no longer be required when cpython-3.9.1 ships