### PR TITLE
remove use of deprecated distutils

### DIFF
--- a/appnope/__init__.py
+++ b/appnope/__init__.py
@@ -1,12 +1,13 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
+import re
 import sys
 import platform
-from distutils.version import LooseVersion as V
 
-if sys.platform != "darwin" or V(platform.mac_ver()[0]) < V("10.9"):
+def _v(version_s):
+    return tuple(int(s) for s in re.findall("\d+", version_s))
+
+if sys.platform != "darwin" or _v(platform.mac_ver()[0]) < _v("10.9"):
     from ._dummy import *
 else:
     from ._nope import *
-
-del sys, platform, V

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,11 @@
 
 from __future__ import print_function
 
-
 import sys
-import platform
 
-from distutils.version import LooseVersion as V
 from setuptools import setup
 from setuptools.command.bdist_egg import bdist_egg
 
-if sys.platform != 'darwin':
-    raise ValueError("Only meant for install on macOS >= 10.9")
-elif V(platform.mac_ver()[0]) < V('10.9'):
-    print("Only meant for install on macOS >= 10.9", file=sys.stderr)
 
 with open('appnope/__init__.py') as f:
     for line in f:


### PR DESCRIPTION
use simple version string parsing

packaging.version is more robust, but way more than we need to handle here, and it's nice to have zero dependencies

closes #13